### PR TITLE
This commit addresses path precedence and variable safety

### DIFF
--- a/templates/go.sh.j2
+++ b/templates/go.sh.j2
@@ -1,2 +1,2 @@
-export GOROOT={{ go_root }}
-export PATH=$PATH:${GOROOT}/bin
+export GOROOT="{{ go_root }}"
+export PATH="${GOROOT}/bin:$PATH"


### PR DESCRIPTION
* Go path should come first in case of other versions of go installed
* Variables should be quoted